### PR TITLE
Feature/nonrl parameters

### DIFF
--- a/output/rl_integer.py
+++ b/output/rl_integer.py
@@ -31,6 +31,8 @@ class RLInteger:
         return levels
 
     def __add__(self, other):
+        if not hasattr(other, 'map_dict'):
+            other = RLInteger({level: other for level in self.map_dict})
         levels = self.combine_levels(other)
         map_dict, curr1, curr2 = ({}, self.map_dict[1], other.map_dict[1])
         for level in levels:
@@ -40,6 +42,8 @@ class RLInteger:
         return RLInteger(map_dict)
 
     def __mul__(self, other):
+        if not hasattr(other, 'map_dict'):
+            other = RLInteger({level: other for level in self.map_dict})
         levels = self.combine_levels(other)
         map_dict, curr1, curr2 = ({}, self.map_dict[1], other.map_dict[1])
         for level in levels:

--- a/static_rlifier.py
+++ b/static_rlifier.py
@@ -29,6 +29,8 @@ class RL{class_name}:
 # Template for the RL class binary methods
 RL_METHOD_TEMPLATE = """
 def {method_name}(self, {other_arg}):
+    if not hasattr({other_arg}, 'map_dict'):
+        {other_arg} = RL{class_name}({{level: {other_arg} for level in self.map_dict}})
     levels = self.combine_levels({other_arg})
     map_dict, curr1, curr2 = {{}}, self.map_dict[1], {other_arg}.map_dict[1]
     for level in levels:

--- a/test.py
+++ b/test.py
@@ -16,6 +16,7 @@ print(RL1.combine_levels(RL2))
 print(RL1.map_dict[1] is RL2.map_dict[0.95])
 print(RL1+RL2)
 print(-RL1)
+print(RL1+Integer(60))
 
 # 71
 # 330


### PR DESCRIPTION
Allow nonrl parameters for binary operators. These nonrl parameters are transformed into an rl with the same level set as the RL we operate on, and the parameter is repeated on each level.